### PR TITLE
Removed i.imgur.com

### DIFF
--- a/PAW/JSON/DeviceConfiguration/PAW-Win10-URLLockProxy-UI_25-11-2020-17-42-13.json
+++ b/PAW/JSON/DeviceConfiguration/PAW-Win10-URLLockProxy-UI_25-11-2020-17-42-13.json
@@ -378,7 +378,7 @@
                                                   "*.office.net",
                                                   "*.officeapps.live.com",
                                                   "aka.ms",
-                                                  "*.powershellgallery.com,i.imgur.com"
+                                                  "*.powershellgallery.com"
                                               ],
                                "useForLocalAddresses":  false
                            },


### PR DESCRIPTION
I removed i.imgur.com from the URL list, also the URL list contains more sites than the list on : https://docs.microsoft.com/en-us/security/compass/privileged-access-deployment#url-lock-proxy